### PR TITLE
Add some diagnostic stuff to track down UI bug #41

### DIFF
--- a/Forms/MainForm.Designer.cs
+++ b/Forms/MainForm.Designer.cs
@@ -54,6 +54,8 @@
             this.ArchetypesEditWidget = new Curvature.Widgets.EditWidgetArchetypes();
             this.ScenariosTab = new System.Windows.Forms.TabPage();
             this.ScenariosEditWidget = new Curvature.Widgets.EditWidgetScenarios();
+            this.tempToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.uIDiagnosticsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.PrimaryMenuStrip.SuspendLayout();
             this.MainTabs.SuspendLayout();
             this.ProjectTab.SuspendLayout();
@@ -68,7 +70,8 @@
             // PrimaryMenuStrip
             // 
             this.PrimaryMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.fileToolStripMenuItem});
+            this.fileToolStripMenuItem,
+            this.tempToolStripMenuItem});
             this.PrimaryMenuStrip.Location = new System.Drawing.Point(0, 0);
             this.PrimaryMenuStrip.Name = "PrimaryMenuStrip";
             this.PrimaryMenuStrip.Size = new System.Drawing.Size(987, 24);
@@ -295,6 +298,21 @@
             this.ScenariosEditWidget.Size = new System.Drawing.Size(955, 597);
             this.ScenariosEditWidget.TabIndex = 0;
             // 
+            // tempToolStripMenuItem
+            // 
+            this.tempToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.uIDiagnosticsToolStripMenuItem});
+            this.tempToolStripMenuItem.Name = "tempToolStripMenuItem";
+            this.tempToolStripMenuItem.Size = new System.Drawing.Size(49, 20);
+            this.tempToolStripMenuItem.Text = "Temp";
+            // 
+            // uIDiagnosticsToolStripMenuItem
+            // 
+            this.uIDiagnosticsToolStripMenuItem.Name = "uIDiagnosticsToolStripMenuItem";
+            this.uIDiagnosticsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.uIDiagnosticsToolStripMenuItem.Text = "UI diagnostics";
+            this.uIDiagnosticsToolStripMenuItem.Click += new System.EventHandler(this.UIDiagnosticsToolStripMenuItem_Click);
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -348,6 +366,8 @@
         private Widgets.EditWidgetBehaviorSets BehaviorSetsEditWidget;
         private Widgets.EditWidgetArchetypes ArchetypesEditWidget;
         private Widgets.EditWidgetScenarios ScenariosEditWidget;
+        private System.Windows.Forms.ToolStripMenuItem tempToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uIDiagnosticsToolStripMenuItem;
     }
 }
 

--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -182,5 +182,31 @@ namespace Curvature
                     Text = $"Curvature Studio - [{EditingFileName}]";
             }
         }
+
+        private void UIDiagnosticsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var output = new StringBuilder();
+
+            output.AppendLine($"Window font face: {Font.Name}");
+            output.AppendLine($"Window font size: {Font.Size}");
+
+            output.AppendLine($"Autoscale factor X: {AutoScaleFactor.Width}");
+            output.AppendLine($"Autoscale factor Y: {AutoScaleFactor.Height}");
+
+            output.AppendLine($"Autoscale basis X: {AutoScaleDimensions.Width}");
+            output.AppendLine($"Autoscale basis Y: {AutoScaleDimensions.Height}");
+
+            output.AppendLine($"Autoscale current X: {CurrentAutoScaleDimensions.Width}");
+            output.AppendLine($"Autoscale current Y: {CurrentAutoScaleDimensions.Height}");
+
+            output.AppendLine($"Scenarios Autoscale basis X: {ScenariosEditWidget.AutoScaleDimensions.Width}");
+            output.AppendLine($"Scenarios Autoscale basis Y: {ScenariosEditWidget.AutoScaleDimensions.Height}");
+
+            output.AppendLine($"Scenarios Autoscale current X: {ScenariosEditWidget.CurrentAutoScaleDimensions.Width}");
+            output.AppendLine($"Scenarios Autoscale current Y: {ScenariosEditWidget.CurrentAutoScaleDimensions.Height}");
+
+            Clipboard.SetText(output.ToString());
+            MessageBox.Show("Copied diagnostic data to clipboard");
+        }
     }
 }


### PR DESCRIPTION
Would you mind merging this change and trying it out? It adds a menu called Temp with a single option called UI Diagnostics. Clicking the menu item will copy some data to the clipboard. I am not entirely sure what information I need to get so this is just a start. If you can paste the output into the Curvature bug (41) that would be super helpful.

Cheers!