### PR TITLE
Another attempt at fixing scaling problem

### DIFF
--- a/Widgets/EditWidgetConsideration.Designer.cs
+++ b/Widgets/EditWidgetConsideration.Designer.cs
@@ -72,6 +72,7 @@
             this.HorizontalSplitter.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.HorizontalSplitter.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
             this.HorizontalSplitter.Location = new System.Drawing.Point(7, 65);
             this.HorizontalSplitter.Name = "HorizontalSplitter";
             this.HorizontalSplitter.Orientation = System.Windows.Forms.Orientation.Horizontal;

--- a/Widgets/EditWidgetResponseCurve.Designer.cs
+++ b/Widgets/EditWidgetResponseCurve.Designer.cs
@@ -106,7 +106,8 @@
             // 
             // CurvePictureBox
             // 
-            this.CurvePictureBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.CurvePictureBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.CurvePictureBox.BackColor = System.Drawing.Color.White;
             this.CurvePictureBox.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
@@ -195,6 +196,8 @@
             // 
             // ShiftLeftButton
             // 
+            this.ShiftLeftButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
             this.ShiftLeftButton.Font = new System.Drawing.Font("Wingdings", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(2)));
             this.ShiftLeftButton.Location = new System.Drawing.Point(140, 25);
             this.ShiftLeftButton.Name = "ShiftLeftButton";
@@ -206,7 +209,8 @@
             // 
             // ShiftRightButton
             // 
-            this.ShiftRightButton.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.ShiftRightButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.ShiftRightButton.Font = new System.Drawing.Font("Wingdings", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(2)));
             this.ShiftRightButton.Location = new System.Drawing.Point(335, 25);
             this.ShiftRightButton.Name = "ShiftRightButton";
@@ -218,6 +222,8 @@
             // 
             // ShiftUpButton
             // 
+            this.ShiftUpButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.ShiftUpButton.Font = new System.Drawing.Font("Wingdings", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(2)));
             this.ShiftUpButton.Location = new System.Drawing.Point(159, 5);
             this.ShiftUpButton.Name = "ShiftUpButton";
@@ -229,7 +235,8 @@
             // 
             // ShiftDownButton
             // 
-            this.ShiftDownButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.ShiftDownButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.ShiftDownButton.Font = new System.Drawing.Font("Wingdings", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(2)));
             this.ShiftDownButton.Location = new System.Drawing.Point(159, 181);
             this.ShiftDownButton.Name = "ShiftDownButton";

--- a/Widgets/EditWidgetResponseCurve.cs
+++ b/Widgets/EditWidgetResponseCurve.cs
@@ -122,19 +122,6 @@ namespace Curvature
 
                 CurvePictureBox.Refresh();
             };
-
-            Resize += (e, args) =>
-            {
-                SuspendLayout();
-                CurvePictureBox.Height = Height - (CurvePictureBox.Top * 2);
-                ShiftDownButton.Width = CurvePictureBox.Width - (2 * ShiftLeftButton.Width) - 3;
-                ShiftDownButton.Top = CurvePictureBox.Bottom - ShiftDownButton.Height - 1;
-                ShiftUpButton.Width = ShiftDownButton.Width;
-                ShiftRightButton.Left = ShiftUpButton.Right;
-                ShiftRightButton.Height = CurvePictureBox.Height - (2 * ShiftUpButton.Height) - 3;
-                ShiftLeftButton.Height = ShiftRightButton.Height;
-                ResumeLayout(false);
-            };
         }
 
         internal void AttachCurve(ResponseCurve curve, Project project)


### PR DESCRIPTION
I found some examples online of SplitContainer controls having scaling issues. This is a very hacky way to find out if that is what is affecting the Response Curve editor UI. If this fixes the problem I have a plan to make a more permanent version that should also help a few other places where SplitContainers are used in Curvature.